### PR TITLE
feat/IS-9: 멤버 정보 조회, 멤버 정보 수정 API 구현

### DIFF
--- a/src/main/java/org/devjeans/sid/domain/member/controller/MemberController.java
+++ b/src/main/java/org/devjeans/sid/domain/member/controller/MemberController.java
@@ -1,16 +1,20 @@
 package org.devjeans.sid.domain.member.controller;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.devjeans.sid.domain.member.dto.MemberInfoResponse;
+import org.devjeans.sid.domain.member.dto.UpdateMemberRequest;
+import org.devjeans.sid.domain.member.dto.UpdateMemberResponse;
 import org.devjeans.sid.domain.member.service.MemberService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/api/member")
 @RestController
@@ -21,5 +25,22 @@ public class MemberController {
         MemberInfoResponse memberInfo = memberService.getMemberInfo(memberId);
 
         return new ResponseEntity<>(memberInfo, HttpStatus.OK);
+    }
+
+    @PostMapping("/{memberId}/update")
+    public ResponseEntity<UpdateMemberResponse> getMemberInfo(@PathVariable("memberId") Long memberId,
+                                          @RequestPart String name,
+                                          @RequestPart String nickname,
+                                          @RequestPart String phoneNumber,
+                                          @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
+//        log.info("line 32 {}", updateMemberRequest);
+        UpdateMemberRequest updateMemberRequest = UpdateMemberRequest.builder()
+                .nickname(nickname)
+                .name(name)
+                .phoneNumber(phoneNumber)
+                .build();
+        UpdateMemberResponse updateMemberResponse = memberService.updateMemberInfo(memberId, updateMemberRequest, profileImage);
+
+        return new ResponseEntity<>(updateMemberResponse, HttpStatus.OK);
     }
 }

--- a/src/main/java/org/devjeans/sid/domain/member/controller/MemberController.java
+++ b/src/main/java/org/devjeans/sid/domain/member/controller/MemberController.java
@@ -1,4 +1,25 @@
 package org.devjeans.sid.domain.member.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.devjeans.sid.domain.member.dto.MemberInfoResponse;
+import org.devjeans.sid.domain.member.service.MemberService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/member")
+@RestController
 public class MemberController {
+    private final MemberService memberService;
+    @GetMapping("/{memberId}")
+    public ResponseEntity<MemberInfoResponse> getMemberInfo(@PathVariable("memberId") Long memberId) {
+        MemberInfoResponse memberInfo = memberService.getMemberInfo(memberId);
+
+        return new ResponseEntity<>(memberInfo, HttpStatus.OK);
+    }
 }

--- a/src/main/java/org/devjeans/sid/domain/member/dto/MemberInfoRequest.java
+++ b/src/main/java/org/devjeans/sid/domain/member/dto/MemberInfoRequest.java
@@ -1,4 +1,0 @@
-package org.devjeans.sid.domain.member.dto;
-
-public class MemberInfoRequest {
-}

--- a/src/main/java/org/devjeans/sid/domain/member/dto/MemberInfoRequest.java
+++ b/src/main/java/org/devjeans/sid/domain/member/dto/MemberInfoRequest.java
@@ -1,0 +1,4 @@
+package org.devjeans.sid.domain.member.dto;
+
+public class MemberInfoRequest {
+}

--- a/src/main/java/org/devjeans/sid/domain/member/dto/MemberInfoResponse.java
+++ b/src/main/java/org/devjeans/sid/domain/member/dto/MemberInfoResponse.java
@@ -1,0 +1,43 @@
+package org.devjeans.sid.domain.member.dto;
+
+import lombok.*;
+import org.devjeans.sid.domain.member.entity.Member;
+import org.devjeans.sid.domain.member.entity.SocialType;
+import org.devjeans.sid.domain.siderCard.entity.SiderCard;
+
+import javax.persistence.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access =  AccessLevel.PROTECTED)
+public class MemberInfoResponse {
+    private Long memberId;
+
+    private String name;
+
+    private String email;
+
+    private String nickname;
+
+    private SocialType socialType;
+
+    private Long socialId;
+
+    private String phoneNumber;
+
+    private String profileImageUrl;
+
+    public static MemberInfoResponse fromEntity(Member member) {
+        return MemberInfoResponse.builder()
+                .memberId(member.getId())
+                .name(member.getName())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .socialType(member.getSocialType())
+                .socialId(member.getSocialId())
+                .phoneNumber(member.getPhoneNumber())
+                .profileImageUrl(member.getProfileImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/org/devjeans/sid/domain/member/dto/UpdateMemberRequest.java
+++ b/src/main/java/org/devjeans/sid/domain/member/dto/UpdateMemberRequest.java
@@ -1,0 +1,4 @@
+package org.devjeans.sid.domain.member.dto;
+
+public class UpdateMemberRequest {
+}

--- a/src/main/java/org/devjeans/sid/domain/member/dto/UpdateMemberRequest.java
+++ b/src/main/java/org/devjeans/sid/domain/member/dto/UpdateMemberRequest.java
@@ -1,4 +1,17 @@
 package org.devjeans.sid.domain.member.dto;
 
+import lombok.*;
+import org.devjeans.sid.domain.member.entity.SocialType;
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Setter
+@Getter
 public class UpdateMemberRequest {
+    private String name;
+
+    private String nickname;
+
+    private String phoneNumber;
 }

--- a/src/main/java/org/devjeans/sid/domain/member/dto/UpdateMemberResponse.java
+++ b/src/main/java/org/devjeans/sid/domain/member/dto/UpdateMemberResponse.java
@@ -1,4 +1,44 @@
 package org.devjeans.sid.domain.member.dto;
 
+import lombok.*;
+import org.devjeans.sid.domain.member.entity.Member;
+import org.devjeans.sid.domain.member.entity.SocialType;
+import org.devjeans.sid.domain.siderCard.entity.SiderCard;
+import org.hibernate.sql.Update;
+
+import javax.persistence.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access =  AccessLevel.PROTECTED)
 public class UpdateMemberResponse {
+    private Long memberId;
+
+    private String name;
+
+    private String email;
+
+    private String nickname;
+
+    private SocialType socialType;
+
+    private Long socialId;
+
+    private String phoneNumber;
+
+    private String profileImageUrl;
+
+    public static UpdateMemberResponse fromEntity(Member member) {
+        return UpdateMemberResponse.builder()
+                .memberId(member.getId())
+                .name(member.getName())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .socialType(member.getSocialType())
+                .socialId(member.getSocialId())
+                .phoneNumber(member.getPhoneNumber())
+                .profileImageUrl(member.getProfileImageUrl())
+                .build();
+    }
 }

--- a/src/main/java/org/devjeans/sid/domain/member/dto/UpdateMemberResponse.java
+++ b/src/main/java/org/devjeans/sid/domain/member/dto/UpdateMemberResponse.java
@@ -1,0 +1,4 @@
+package org.devjeans.sid.domain.member.dto;
+
+public class UpdateMemberResponse {
+}

--- a/src/main/java/org/devjeans/sid/domain/member/entity/Member.java
+++ b/src/main/java/org/devjeans/sid/domain/member/entity/Member.java
@@ -35,6 +35,8 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private String phoneNumber;
 
+    private String profileImageUrl;
+
     @OneToOne(mappedBy = "member",cascade = CascadeType.ALL)
     private SiderCard siderCard;
 

--- a/src/main/java/org/devjeans/sid/domain/member/entity/Member.java
+++ b/src/main/java/org/devjeans/sid/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package org.devjeans.sid.domain.member.entity;
 import lombok.Getter;
 import org.devjeans.sid.domain.common.BaseEntity;
 import org.devjeans.sid.domain.launchedProject.entity.LaunchedProjectScrap;
+import org.devjeans.sid.domain.member.dto.UpdateMemberRequest;
 import org.devjeans.sid.domain.projectMember.entity.ProjectMember;
 import org.devjeans.sid.domain.projectScrap.entity.ProjectScrap;
 import org.devjeans.sid.domain.siderCard.entity.SiderCard;
@@ -59,5 +60,16 @@ public class Member extends BaseEntity {
 
 //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
 //    private List<ChatMessage> chatMessages = new ArrayList<>();
+
+    //== Custom methos ==//
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void updateMemberInfo(UpdateMemberRequest updateMemberRequest) {
+        this.name = updateMemberRequest.getName();
+        this.nickname = updateMemberRequest.getNickname();
+        this.phoneNumber = updateMemberRequest.getPhoneNumber();
+    }
 
 }

--- a/src/main/java/org/devjeans/sid/domain/member/entity/Member.java
+++ b/src/main/java/org/devjeans/sid/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package org.devjeans.sid.domain.member.entity;
 
+import lombok.Getter;
 import org.devjeans.sid.domain.common.BaseEntity;
 import org.devjeans.sid.domain.launchedProject.entity.LaunchedProjectScrap;
 import org.devjeans.sid.domain.projectMember.entity.ProjectMember;
@@ -10,6 +11,7 @@ import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
+@Getter
 @Entity
 public class Member extends BaseEntity {
     @Id
@@ -43,14 +45,14 @@ public class Member extends BaseEntity {
 //    @OneToMany(mappedBy = "member", cascade = CascadeType.PERSIST)
 //    private List<LaunchedProjectMember> launchedProjectMembers = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.PERSIST)
-    private List<ProjectMember> projectMembers = new ArrayList<>();
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
-    private List<ProjectScrap> projectScraps = new ArrayList<>();
-
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
-    private List<LaunchedProjectScrap> launchedProjectScraps = new ArrayList<>();
+//    @OneToMany(mappedBy = "member", cascade = CascadeType.PERSIST)
+//    private List<ProjectMember> projectMembers = new ArrayList<>();
+//
+//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+//    private List<ProjectScrap> projectScraps = new ArrayList<>();
+//
+//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+//    private List<LaunchedProjectScrap> launchedProjectScraps = new ArrayList<>();
 
 //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
 //    private List<ChatParticipant> chatParticipants = new ArrayList<>();

--- a/src/main/java/org/devjeans/sid/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/devjeans/sid/domain/member/repository/MemberRepository.java
@@ -1,2 +1,14 @@
-package org.devjeans.sid.domain.member.repository;public interface MemberRepository {
+package org.devjeans.sid.domain.member.repository;
+
+import org.devjeans.sid.domain.member.entity.Member;
+import org.devjeans.sid.global.exception.BaseException;
+import org.devjeans.sid.global.exception.exceptionType.MemberExceptionType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import static org.devjeans.sid.global.exception.exceptionType.MemberExceptionType.MEMBER_NOT_FOUND;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    default Member findByIdOrThrow(Long memberId) {
+        return findById(memberId).orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
+    }
 }

--- a/src/main/java/org/devjeans/sid/domain/member/service/MemberService.java
+++ b/src/main/java/org/devjeans/sid/domain/member/service/MemberService.java
@@ -1,0 +1,19 @@
+package org.devjeans.sid.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.devjeans.sid.domain.member.dto.MemberInfoResponse;
+import org.devjeans.sid.domain.member.entity.Member;
+import org.devjeans.sid.domain.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+    private final MemberRepository memberRepository;
+    public MemberInfoResponse getMemberInfo(Long memberId) {
+        // TODO: 인증, 인가 구현 후 멤버 아이디와 시큐리티 컨텍스트의 멤버가 동일한지 확인하는 로직 필요
+
+        Member member = memberRepository.findByIdOrThrow(memberId);
+        return MemberInfoResponse.fromEntity(member);
+    }
+}

--- a/src/main/java/org/devjeans/sid/domain/member/service/MemberService.java
+++ b/src/main/java/org/devjeans/sid/domain/member/service/MemberService.java
@@ -2,18 +2,61 @@ package org.devjeans.sid.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
 import org.devjeans.sid.domain.member.dto.MemberInfoResponse;
+import org.devjeans.sid.domain.member.dto.UpdateMemberRequest;
+import org.devjeans.sid.domain.member.dto.UpdateMemberResponse;
 import org.devjeans.sid.domain.member.entity.Member;
 import org.devjeans.sid.domain.member.repository.MemberRepository;
+import org.devjeans.sid.global.exception.BaseException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.devjeans.sid.global.exception.exceptionType.MemberExceptionType.INVALID_PROFILE_IMAGE;
 
 @RequiredArgsConstructor
 @Service
 public class MemberService {
     private final MemberRepository memberRepository;
+
+    private static final String STORAGE_DIR = "/Users/sejeong/Documents/besw-devjeans/temp"; // 실제 저장 경로로 변경
     public MemberInfoResponse getMemberInfo(Long memberId) {
         // TODO: 인증, 인가 구현 후 멤버 아이디와 시큐리티 컨텍스트의 멤버가 동일한지 확인하는 로직 필요
 
         Member member = memberRepository.findByIdOrThrow(memberId);
         return MemberInfoResponse.fromEntity(member);
+    }
+
+    @Transactional
+    public UpdateMemberResponse updateMemberInfo(Long memberId,
+                                                 UpdateMemberRequest updateMemberRequest,
+                                                 MultipartFile profileImage) {
+        Member member = memberRepository.findByIdOrThrow(memberId);
+
+        // 회원의 프로필 사진을 스토리지에 저장
+        if (profileImage != null && !profileImage.isEmpty()) {
+            String newFileName = memberId + "_" + profileImage.getOriginalFilename();
+            Path path = Paths.get(STORAGE_DIR, newFileName);
+
+            try {
+                Files.write(path, profileImage.getBytes());
+            } catch(IOException e) {
+                throw new BaseException(INVALID_PROFILE_IMAGE);
+            }
+
+
+            member.updateProfileImageUrl(path.toString());
+
+        }
+
+        // 회원 정보 수정
+        member.updateMemberInfo(updateMemberRequest);
+        Member updatedMember = memberRepository.save(member);
+
+        return UpdateMemberResponse.fromEntity(updatedMember);
     }
 }

--- a/src/main/java/org/devjeans/sid/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/devjeans/sid/global/exception/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package org.devjeans.sid.global.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.devjeans.sid.global.exception.exceptionType.ExceptionType;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(BaseException.class)
@@ -19,6 +21,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.info("[Unhandled Error] {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ErrorResponse.builder()
                         .name(HttpStatus.INTERNAL_SERVER_ERROR.name())

--- a/src/main/java/org/devjeans/sid/global/exception/exceptionType/MemberExceptionType.java
+++ b/src/main/java/org/devjeans/sid/global/exception/exceptionType/MemberExceptionType.java
@@ -7,7 +7,8 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @RequiredArgsConstructor
 public enum MemberExceptionType implements ExceptionType {
-    MEMBER_NOT_FOUND(BAD_REQUEST, "회원이 존재하지 않습니다.");
+    MEMBER_NOT_FOUND(BAD_REQUEST, "회원이 존재하지 않습니다."),
+    INVALID_PROFILE_IMAGE(BAD_REQUEST, "잘못된 형식의 프로필 사진입니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- 멤버 아이디로 멤버의 정보를 조회할 수 있는 API를 만들었습니다.
- 멤버의 정보를 수정할 수 있는 API를 만들었습니다.
관련 화면:
<img width="486" alt="스크린샷 2024-07-22 오후 11 41 11" src="https://github.com/user-attachments/assets/17ef6e4f-7fc5-4c7f-b7ad-22316bfecc32">


## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
멤버 정보 조회 결과
<img width="858" alt="스크린샷 2024-07-22 오후 10 51 23" src="https://github.com/user-attachments/assets/58d28f7d-916e-49fa-a3f4-8e8f5546b6be">


멤버 정보 수정 결과
(수정할 수 있는 정보는 이름, 닉네임, 전화번호, 프로필 사진입니다.)
<img width="843" alt="스크린샷 2024-07-22 오후 11 37 38" src="https://github.com/user-attachments/assets/cf3c5946-5fe3-409c-8ea4-d30f6f24242b">


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

- 현재 인증이 구현돼있지 않아서 해당 로직을 구현할 수 없었지만,
추후 스프링 시큐리티로 인증을 구현하면, 시큐리티 컨텍스트에서 현재 로그인한 유저 아이디를 꺼내와서 요청으로 들어온 유저 아이디와 동일한지 비교하는 로직이 필요합니다. `// TODO `주석 지우지 말아주세용!! (자신이 아닌 회원의 정보를 조회, 수정 할 수 없도록)

- `Member` 엔티티에서 `@OneToMany` 릴레이션을 모두 주석 처리해놓았는데, 추후 필요성이 느껴지면 주석 해제해서 사용하도록 하겠습니다!

- 이메일을 변경하는 기능은 이메일 인증이 필요하므로, 별도 API로 구현 예정입니다.

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
feat/IS-9 -> main