### PR TITLE
feat/IS-10: 채팅방 목록 조회 & 채팅 내용 조회 API 작성

### DIFF
--- a/src/main/java/org/devjeans/sid/domain/chatRoom/chatService/ChatService.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/chatService/ChatService.java
@@ -1,0 +1,54 @@
+package org.devjeans.sid.domain.chatRoom.chatService;
+
+import lombok.RequiredArgsConstructor;
+import org.devjeans.sid.domain.chatRoom.dto.ChatRoomSimpleResponse;
+import org.devjeans.sid.domain.chatRoom.entity.ChatMessage;
+import org.devjeans.sid.domain.chatRoom.entity.ChatParticipant;
+import org.devjeans.sid.domain.chatRoom.entity.ChatRoom;
+import org.devjeans.sid.domain.chatRoom.repository.ChatMessageRepository;
+import org.devjeans.sid.domain.chatRoom.repository.ChatParticipantRepository;
+import org.devjeans.sid.domain.chatRoom.repository.ChatRoomRepository;
+import org.devjeans.sid.domain.member.entity.Member;
+import org.devjeans.sid.domain.member.repository.MemberRepository;
+import org.devjeans.sid.global.exception.BaseException;
+import org.devjeans.sid.global.exception.exceptionType.ChatExceptionType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+import static org.devjeans.sid.global.exception.exceptionType.ChatExceptionType.INVALID_CHATROOM;
+
+@RequiredArgsConstructor
+@Service
+public class ChatService {
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatParticipantRepository chatParticipantRepository;
+    private final MemberRepository memberRepository;
+
+    // 해당 회원이 속한 채팅방을 updatedAt DESC로 정렬해서 보여주기
+    public Page<ChatRoomSimpleResponse> getChatRoomList(Pageable pageable, Long memberId) {
+        Page<ChatRoom> chatRooms = chatRoomRepository.findAllByMemberIdOrderByUpdatedAtDesc(pageable, memberId);
+
+         // TODO: 로직 잘 맞는지 다시 검증
+        return chatRooms.map(r -> {
+            ChatParticipant chatParticipant = r.getChatParticipants().stream()
+                    .filter(p -> !p.getMember().getId().equals(memberId))
+                    .findFirst()
+                    .orElseThrow(() -> new BaseException(INVALID_CHATROOM));
+
+            Page<ChatMessage> unreadMessages = chatMessageRepository.findAllByIsReadAndChatRoomIdOrderByUpdatedAt(pageable,false, r.getId());
+
+            ChatMessage recentMessage = null;
+            // unread Message가 없을 경우 처리
+            if (!unreadMessages.getContent().isEmpty()) {
+                unreadMessage = unreadMessages.getContent().get(0);
+            }
+
+            return ChatRoomSimpleResponse.fromEntity(r, unreadMessages.getTotalElements(), chatParticipant.getMember(), unreadMessage.getContent());
+        });
+    }
+}

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/controller/ChatController.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/controller/ChatController.java
@@ -1,0 +1,27 @@
+package org.devjeans.sid.domain.chatRoom.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.devjeans.sid.domain.chatRoom.chatService.ChatService;
+import org.devjeans.sid.domain.chatRoom.dto.ChatRoomSimpleResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+@RestController
+public class ChatController {
+    private final ChatService chatService;
+    @GetMapping("/member/{memberId}/list")
+    public ResponseEntity<Page<ChatRoomSimpleResponse>> getChatRoomList(@PageableDefault(size = 5) Pageable pageable, @PathVariable("memberId") Long memberId) {
+        Page<ChatRoomSimpleResponse> chatRoomList = chatService.getChatRoomList(pageable, memberId);
+
+        return new ResponseEntity<>(chatRoomList, HttpStatus.OK);
+    }
+}

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/controller/ChatController.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/controller/ChatController.java
@@ -2,6 +2,7 @@ package org.devjeans.sid.domain.chatRoom.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.devjeans.sid.domain.chatRoom.chatService.ChatService;
+import org.devjeans.sid.domain.chatRoom.dto.ChatRoomListResponse;
 import org.devjeans.sid.domain.chatRoom.dto.ChatRoomSimpleResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/controller/ChatController.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/controller/ChatController.java
@@ -3,9 +3,11 @@ package org.devjeans.sid.domain.chatRoom.controller;
 import lombok.RequiredArgsConstructor;
 import org.devjeans.sid.domain.chatRoom.chatService.ChatService;
 import org.devjeans.sid.domain.chatRoom.dto.ChatRoomListResponse;
+import org.devjeans.sid.domain.chatRoom.dto.ChatRoomMessageResponse;
 import org.devjeans.sid.domain.chatRoom.dto.ChatRoomSimpleResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,5 +26,15 @@ public class ChatController {
         Page<ChatRoomSimpleResponse> chatRoomList = chatService.getChatRoomList(pageable, memberId);
 
         return new ResponseEntity<>(chatRoomList, HttpStatus.OK);
+    }
+
+    // createdAt의 내림차순으로 뿌려주기, 보낸사람 아이디, 내용, 보낸 시간
+    @GetMapping("/chat-room/{chatRoomId}/receiver/{memberId}")
+    public ResponseEntity<Slice<ChatRoomMessageResponse>> getChatRoomMessages(@PageableDefault(size = 10) Pageable pageable,
+                                                                              @PathVariable("chatRoomId") Long chatRoomId,
+                                                                              @PathVariable("memberId") Long memberId) {
+        Slice<ChatRoomMessageResponse> chatRoomMessages = chatService.getChatRoomMessages(pageable, chatRoomId, memberId);
+
+        return new ResponseEntity<>(chatRoomMessages, HttpStatus.OK);
     }
 }

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/dto/ChatRoomListResponse.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/dto/ChatRoomListResponse.java
@@ -1,0 +1,14 @@
+package org.devjeans.sid.domain.chatRoom.dto;
+
+import lombok.*;
+
+import java.util.List;
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ChatRoomListResponse {
+    private Long totalCount; // 총 채팅방 몇개?
+    private int currentPage; // 현재 몇번 페이지?
+    private List<ChatRoomSimpleResponse> chatRoomList;
+}

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/dto/ChatRoomMessageResponse.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/dto/ChatRoomMessageResponse.java
@@ -1,0 +1,25 @@
+package org.devjeans.sid.domain.chatRoom.dto;
+
+import lombok.*;
+import org.devjeans.sid.domain.chatRoom.entity.ChatMessage;
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ChatRoomMessageResponse {
+    private Long sender;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public static ChatRoomMessageResponse fromEntity(ChatMessage message) {
+        return ChatRoomMessageResponse.builder()
+                .sender(message.getMember().getId())
+                .content(message.getContent())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/dto/ChatRoomSimpleResponse.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/dto/ChatRoomSimpleResponse.java
@@ -13,7 +13,7 @@ public class ChatRoomSimpleResponse { // 밖에서 미리보기처럼 보이는 
     private Long projectId;
     private Long participantId; // 상대방의 멤버 아이디
     private String participantNickName; // 상대방 이름
-    private String participantProfile; // 상대방 프로필 사진
+    private String participantProfileImageUrl; // 상대방 프로필 사진
     private Long unreadCount; // 읽었는지 여부
     private String unreadContent; // 채팅 내용
 
@@ -23,7 +23,7 @@ public class ChatRoomSimpleResponse { // 밖에서 미리보기처럼 보이는 
                 .projectId(chatRoom.getProject().getId())
                 .participantId(participant.getId())
                 .participantNickName(participant.getNickname())
-                .participantProfile(participant.getProfileImageUrl())
+                .participantProfileImageUrl(participant.getProfileImageUrl())
                 .unreadCount(unreadCount)
                 .unreadContent(unreadContent)
                 .build();

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/dto/ChatRoomSimpleResponse.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/dto/ChatRoomSimpleResponse.java
@@ -1,0 +1,30 @@
+package org.devjeans.sid.domain.chatRoom.dto;
+
+import lombok.*;
+import org.devjeans.sid.domain.chatRoom.entity.ChatRoom;
+import org.devjeans.sid.domain.member.entity.Member;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ChatRoomSimpleResponse { // 밖에서 미리보기처럼 보이는 채팅방 1개의 정보
+    private Long chatRoomId;
+    private Long projectId;
+    private String participantNickName; // 상대방 이름
+    private String participantProfile; // 상대방 프로필 사진
+    private Long unreadCount; // 읽었는지 여부
+    private String unreadContent; // 채팅 내용
+
+    public static ChatRoomSimpleResponse fromEntity(ChatRoom chatRoom, Long unreadCount, Member participant, String unreadContent) {
+        return ChatRoomSimpleResponse.builder()
+                .chatRoomId(chatRoom.getId())
+                .projectId(chatRoom.getProject().getId())
+                .participantNickName(participant.getNickname())
+                .participantProfile(participant.getProfileImageUrl())
+                .unreadCount(unreadCount)
+                .unreadContent(unreadContent)
+                .build();
+    }
+
+}

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/dto/ChatRoomSimpleResponse.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/dto/ChatRoomSimpleResponse.java
@@ -11,6 +11,7 @@ import org.devjeans.sid.domain.member.entity.Member;
 public class ChatRoomSimpleResponse { // 밖에서 미리보기처럼 보이는 채팅방 1개의 정보
     private Long chatRoomId;
     private Long projectId;
+    private Long participantId; // 상대방의 멤버 아이디
     private String participantNickName; // 상대방 이름
     private String participantProfile; // 상대방 프로필 사진
     private Long unreadCount; // 읽었는지 여부
@@ -20,6 +21,7 @@ public class ChatRoomSimpleResponse { // 밖에서 미리보기처럼 보이는 
         return ChatRoomSimpleResponse.builder()
                 .chatRoomId(chatRoom.getId())
                 .projectId(chatRoom.getProject().getId())
+                .participantId(participant.getId())
                 .participantNickName(participant.getNickname())
                 .participantProfile(participant.getProfileImageUrl())
                 .unreadCount(unreadCount)

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/entity/ChatMessage.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/entity/ChatMessage.java
@@ -30,4 +30,9 @@ public class ChatMessage extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+
+    public void readMessage() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/entity/ChatMessage.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/entity/ChatMessage.java
@@ -1,12 +1,13 @@
 package org.devjeans.sid.domain.chatRoom.entity;
 
-import org.devjeans.sid.domain.chatRoom.entity.ChatRoom;
+import lombok.Getter;
 import org.devjeans.sid.domain.common.BaseEntity;
 import org.devjeans.sid.domain.member.entity.Member;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
+@Getter
 @Entity
 public class ChatMessage extends BaseEntity {
     @Id

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/entity/ChatMessage.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/entity/ChatMessage.java
@@ -21,9 +21,11 @@ public class ChatMessage extends BaseEntity {
     @Column(nullable = false,length = 1000)
     private String content;
 
+    // 읽었는지 여부
     @Column(nullable = false)
-    private LocalDateTime sentAt;
+    private Boolean isRead;
 
+    // 보낸 사람
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/entity/ChatMessage.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/entity/ChatMessage.java
@@ -1,4 +1,4 @@
-package org.devjeans.sid.domain.chatMessage.entity;
+package org.devjeans.sid.domain.chatRoom.entity;
 
 import org.devjeans.sid.domain.chatRoom.entity.ChatRoom;
 import org.devjeans.sid.domain.common.BaseEntity;

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/entity/ChatParticipant.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/entity/ChatParticipant.java
@@ -1,11 +1,13 @@
 package org.devjeans.sid.domain.chatRoom.entity;
 
+import lombok.Getter;
 import org.devjeans.sid.domain.chatRoom.entity.ChatRoom;
 import org.devjeans.sid.domain.common.BaseEntity;
 import org.devjeans.sid.domain.member.entity.Member;
 
 import javax.persistence.*;
 
+@Getter
 @Entity
 public class ChatParticipant extends BaseEntity {
     @Id

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/entity/ChatParticipant.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/entity/ChatParticipant.java
@@ -1,4 +1,4 @@
-package org.devjeans.sid.domain.chatParticipant.entity;
+package org.devjeans.sid.domain.chatRoom.entity;
 
 import org.devjeans.sid.domain.chatRoom.entity.ChatRoom;
 import org.devjeans.sid.domain.common.BaseEntity;

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/entity/ChatRoom.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/entity/ChatRoom.java
@@ -1,5 +1,6 @@
 package org.devjeans.sid.domain.chatRoom.entity;
 
+import lombok.Getter;
 import org.devjeans.sid.domain.common.BaseEntity;
 import org.devjeans.sid.domain.project.entity.Project;
 
@@ -7,6 +8,7 @@ import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
+@Getter
 @Entity
 public class ChatRoom extends BaseEntity {
     @Id

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/entity/ChatRoom.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/entity/ChatRoom.java
@@ -1,7 +1,5 @@
 package org.devjeans.sid.domain.chatRoom.entity;
 
-import org.devjeans.sid.domain.chatMessage.entity.ChatMessage;
-import org.devjeans.sid.domain.chatParticipant.entity.ChatParticipant;
 import org.devjeans.sid.domain.common.BaseEntity;
 import org.devjeans.sid.domain.project.entity.Project;
 

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/repository/ChatMessageRepository.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/repository/ChatMessageRepository.java
@@ -1,5 +1,6 @@
 package org.devjeans.sid.domain.chatRoom.repository;
 
+import org.devjeans.sid.domain.chatRoom.dto.ChatRoomMessageResponse;
 import org.devjeans.sid.domain.chatRoom.entity.ChatMessage;
 import org.devjeans.sid.domain.chatRoom.entity.ChatRoom;
 import org.devjeans.sid.domain.member.entity.Member;
@@ -19,4 +20,9 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     @Query("select m from ChatMessage m where m.chatRoom = :chatRoom order by m.createdAt desc")
     List<ChatMessage> findRecentMessageByChatRoom(@Param("chatRoom") ChatRoom chatRoom);
+
+    @Query("select m from ChatMessage m where m.chatRoom.id = :chatRoomId order by m.createdAt desc")
+    Slice<ChatMessage> findAllByChatRoomId(Pageable pageable, @Param("chatRoomId") Long chatRoomId);
+
+    List<ChatMessage> findChatMessageByChatRoomAndIsReadAndMember(ChatRoom chatRoom, boolean b, Member participant);
 }

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/repository/ChatMessageRepository.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/repository/ChatMessageRepository.java
@@ -1,2 +1,12 @@
-package org.devjeans.sid.domain.chatRoom.repository;public class ChatMessageRepository {
+package org.devjeans.sid.domain.chatRoom.repository;
+
+import org.devjeans.sid.domain.chatRoom.entity.ChatMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    Page<ChatMessage> findAllByIsReadAndChatRoomIdOrderByUpdatedAt(Pageable pageable, Boolean isRead, Long chatRoomId);
+//    Long countChatMessageByIsRead(Boolean isRead);
 }

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/repository/ChatMessageRepository.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/repository/ChatMessageRepository.java
@@ -1,12 +1,22 @@
 package org.devjeans.sid.domain.chatRoom.repository;
 
 import org.devjeans.sid.domain.chatRoom.entity.ChatMessage;
+import org.devjeans.sid.domain.chatRoom.entity.ChatRoom;
+import org.devjeans.sid.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-    Page<ChatMessage> findAllByIsReadAndChatRoomIdOrderByUpdatedAt(Pageable pageable, Boolean isRead, Long chatRoomId);
-//    Long countChatMessageByIsRead(Boolean isRead);
+//    Page<ChatMessage> findAllByAndChatRoomIdOrderByUpdatedAt(Pageable pageable, Long chatRoomId);
+    Long countChatMessageByChatRoomAndIsReadAndMember(ChatRoom chatRoom, Boolean isRead, Member member);
+
+    @Query("select m from ChatMessage m where m.chatRoom = :chatRoom order by m.createdAt desc")
+    List<ChatMessage> findRecentMessageByChatRoom(@Param("chatRoom") ChatRoom chatRoom);
 }

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/repository/ChatParticipantRepository.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/repository/ChatParticipantRepository.java
@@ -3,5 +3,8 @@ package org.devjeans.sid.domain.chatRoom.repository;
 import org.devjeans.sid.domain.chatRoom.entity.ChatParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
+    List<ChatParticipant> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/repository/ChatParticipantRepository.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/repository/ChatParticipantRepository.java
@@ -1,2 +1,7 @@
-package org.devjeans.sid.domain.chatRoom.repository;public interface ChatParticipantRepository {
+package org.devjeans.sid.domain.chatRoom.repository;
+
+import org.devjeans.sid.domain.chatRoom.entity.ChatParticipant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
 }

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/repository/ChatRoomRepository.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/repository/ChatRoomRepository.java
@@ -8,7 +8,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-    @Query("select r from ChatRoom r inner join ChatParticipant p on r.id = p.chatRoom.id where p.id = :memberId order by r.updatedAt desc")
+    @Query("select r from ChatRoom r inner join fetch ChatParticipant p on r.id = p.chatRoom.id where p.chatRoom.id = :memberId order by r.updatedAt desc")
     Page<ChatRoom> findAllByMemberIdOrderByUpdatedAtDesc(Pageable pageable, @Param("memberId") Long memberId);
+
+    @Query("select r from ChatRoom r where r.id in :ids and r.chatMessages.size >= 1 order by r.updatedAt")
+    Page<ChatRoom> findAllByIds(Pageable pageable, @Param("ids") List<Long> ids);
 }

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/repository/ChatRoomRepository.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/repository/ChatRoomRepository.java
@@ -1,7 +1,14 @@
 package org.devjeans.sid.domain.chatRoom.repository;
 
 import org.devjeans.sid.domain.chatRoom.entity.ChatRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    @Query("select r from ChatRoom r inner join ChatParticipant p on r.id = p.chatRoom.id where p.id = :memberId order by r.updatedAt desc")
+    Page<ChatRoom> findAllByMemberIdOrderByUpdatedAtDesc(Pageable pageable, @Param("memberId") Long memberId);
 }

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/repository/ChatRoomRepository.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/repository/ChatRoomRepository.java
@@ -1,6 +1,8 @@
 package org.devjeans.sid.domain.chatRoom.repository;
 
 import org.devjeans.sid.domain.chatRoom.entity.ChatRoom;
+import org.devjeans.sid.global.exception.BaseException;
+import org.devjeans.sid.global.exception.exceptionType.ChatExceptionType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -10,10 +12,16 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
+import static org.devjeans.sid.global.exception.exceptionType.ChatExceptionType.NO_CHATROOM;
+
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     @Query("select r from ChatRoom r inner join fetch ChatParticipant p on r.id = p.chatRoom.id where p.chatRoom.id = :memberId order by r.updatedAt desc")
     Page<ChatRoom> findAllByMemberIdOrderByUpdatedAtDesc(Pageable pageable, @Param("memberId") Long memberId);
 
     @Query("select r from ChatRoom r where r.id in :ids and r.chatMessages.size >= 1 order by r.updatedAt")
     Page<ChatRoom> findAllByIds(Pageable pageable, @Param("ids") List<Long> ids);
+
+    default ChatRoom findByIdOrThrow(Long id) {
+        return findById(id).orElseThrow(() -> new BaseException(NO_CHATROOM));
+    }
 }

--- a/src/main/java/org/devjeans/sid/domain/common/BaseEntity.java
+++ b/src/main/java/org/devjeans/sid/domain/common/BaseEntity.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
-    @Column(updatable = false)
+    @Column(updatable = false, columnDefinition = "TIMESTAMP(6)")
     @CreatedDate
     private LocalDateTime createdAt;
 

--- a/src/main/java/org/devjeans/sid/domain/project/entity/Project.java
+++ b/src/main/java/org/devjeans/sid/domain/project/entity/Project.java
@@ -1,5 +1,6 @@
 package org.devjeans.sid.domain.project.entity;
 
+import lombok.Getter;
 import org.devjeans.sid.domain.chatRoom.entity.ChatRoom;
 import org.devjeans.sid.domain.common.BaseEntity;
 import org.devjeans.sid.domain.projectMember.entity.ProjectMember;
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+@Getter
 @Entity
 public class Project extends BaseEntity {
     @Id

--- a/src/main/java/org/devjeans/sid/global/exception/exceptionType/ChatExceptionType.java
+++ b/src/main/java/org/devjeans/sid/global/exception/exceptionType/ChatExceptionType.java
@@ -9,7 +9,8 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 @RequiredArgsConstructor
 public enum ChatExceptionType implements ExceptionType {
     INVALID_CHATROOM(BAD_REQUEST, "유효하지 않은 채팅방입니다."),
-    NO_CHATROOM(NOT_FOUND, "채팅방이 존재하지 않습니다.");
+    NO_CHATROOM(NOT_FOUND, "채팅방이 존재하지 않습니다."),
+    NO_RECENT_MESSAGE(NOT_FOUND, "채팅방에 메시지가 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/devjeans/sid/global/exception/exceptionType/ChatExceptionType.java
+++ b/src/main/java/org/devjeans/sid/global/exception/exceptionType/ChatExceptionType.java
@@ -1,0 +1,26 @@
+package org.devjeans.sid.global.exception.exceptionType;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@RequiredArgsConstructor
+public enum ChatExceptionType implements ExceptionType {
+    INVALID_CHATROOM(BAD_REQUEST, "유효하지 않은 채팅방입니다."),
+    NO_CHATROOM(NOT_FOUND, "채팅방이 존재하지 않습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return status;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: org.mariadb.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     database: mysql
     database-platform: org.hibernate.dialect.MariaDBDialect
     generate-ddl: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: org.mariadb.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     database: mysql
     database-platform: org.hibernate.dialect.MariaDBDialect
     generate-ddl: true


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- 자신이 속한 채팅방 목록 `updatedAt`의 내림차순으로 조회하는 API를 작성했습니다. (아래는 관련 화면)
<img width="355" alt="image" src="https://github.com/user-attachments/assets/34bfa06a-3ee0-4e33-8a0d-0e32d5dd38bd">

- 특정 채팅방의 채팅 목록을 `createdAt`의 내림차순으로 조회하는 API를 작성했습니다. (아래는 관련 화면)
<img width="662" alt="image" src="https://github.com/user-attachments/assets/3d0587af-6bde-413c-8028-d8aeaf4588ab">



## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
<img width="860" alt="스크린샷 2024-07-24 오전 12 37 13" src="https://github.com/user-attachments/assets/3d5f0c0e-6dac-479c-a12b-e95840c3bbe3">
<img width="860" alt="스크린샷 2024-07-24 오전 12 35 02" src="https://github.com/user-attachments/assets/02887b9d-d81f-4bcc-90bb-252a3d690258">


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->
기존엔 밀리초 단위로 저장되지 않았는데, 채팅 메시지 순서 이슈때문에 BaseEntity의 createdAt을 다음과 같이 TIMESTAMP로 변경했습니다.
pull 받으시면 yml에서 `ddl-auto: create`로 놓고 한번 실행 부탁드려용... (테이블들의 컬럼 데이터타입이 바뀌어야해서)
<img width="620" alt="image" src="https://github.com/user-attachments/assets/17afee8a-827b-4bda-9d13-e43aafb8a333">

우리팀 화이팅!!

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
feat/IS-10 -> main