### PR TITLE
feat/IS-16: memberId를 가져오는 SecurityUtil 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 	// STOMP
 	implementation 'org.webjars:stomp-websocket:2.3.4'
 
-// SockJS
+	// SockJS
 	implementation 'org.webjars:sockjs-client:1.5.1'
 
 	//	jwt토큰 관련 라이브러리 추가

--- a/src/main/java/org/devjeans/sid/domain/auth/JwtAuthfilter.java
+++ b/src/main/java/org/devjeans/sid/domain/auth/JwtAuthfilter.java
@@ -31,7 +31,7 @@ public class JwtAuthfilter extends GenericFilter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         String bearerToken = ((HttpServletRequest)request).getHeader("Authorization");
-        try{
+//        try{
             if(bearerToken!=null){
 //            token은 관례적으로 Bearer 로 시작하는 문구를 넣어서 요청
                 if(!bearerToken.substring(0,7).equals("Bearer ")){
@@ -52,12 +52,12 @@ public class JwtAuthfilter extends GenericFilter {
             }
 //        filterchain에서 그 다음 filtering로 넘어가도록하는 메서드
             chain.doFilter(request,response);
-        }catch (Exception e){
-            log.error(e.getMessage(),e);
-            HttpServletResponse httpServletResponse = (HttpServletResponse) response;
-            httpServletResponse.setStatus(HttpStatus.UNAUTHORIZED.value());
-            httpServletResponse.setContentType("application/json;charset=utf-8");
-            httpServletResponse.getWriter().write("token에러");
-        }
+//        }catch (Exception e){
+//            log.error(e.getMessage(),e);
+//            HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+//            httpServletResponse.setStatus(HttpStatus.UNAUTHORIZED.value());
+//            httpServletResponse.setContentType("application/json;charset=utf-8");
+//            httpServletResponse.getWriter().write("token에러");
+//        }
     }
 }

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/service/ChatService.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/service/ChatService.java
@@ -15,6 +15,7 @@ import org.devjeans.sid.domain.member.repository.MemberRepository;
 import org.devjeans.sid.domain.project.entity.Project;
 import org.devjeans.sid.domain.project.repository.ProjectRepository;
 import org.devjeans.sid.global.exception.BaseException;
+import org.devjeans.sid.global.util.SecurityUtil;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -35,8 +36,9 @@ public class ChatService {
     private final ChatParticipantRepository chatParticipantRepository;
     private final MemberRepository memberRepository;
     private final ProjectRepository projectRepository;
-
     private final ConnectedMap connectedMap;
+
+    private final SecurityUtil securityUtil;
 
     // 해당 회원이 속한 채팅방을 updatedAt DESC로 정렬해서 보여주기
     public Page<ChatRoomSimpleResponse> getChatRoomList(Pageable pageable, Long memberId) {
@@ -46,6 +48,9 @@ public class ChatService {
                 .map(p -> p.getChatRoom().getId())
                 .distinct()
                 .collect(Collectors.toList());
+        
+        // util test
+        log.info("[line 53] memberId: {}", securityUtil.getCurrentMemberId());
 
         // 최신 순 정렬
         Page<ChatRoom> chatRooms = chatRoomRepository.findAllByIds(pageable, chatRoomIds);

--- a/src/main/java/org/devjeans/sid/domain/member/entity/Role.java
+++ b/src/main/java/org/devjeans/sid/domain/member/entity/Role.java
@@ -1,5 +1,6 @@
 package org.devjeans.sid.domain.member.entity;
 
 public enum Role {
-    USER,ADMIN
+    USER,
+    ADMIN
 }

--- a/src/main/java/org/devjeans/sid/global/exception/exceptionType/AuthException.java
+++ b/src/main/java/org/devjeans/sid/global/exception/exceptionType/AuthException.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum AuthException implements ExceptionType {
-    UNAUTHENTICATED_USER(HttpStatus.UNAUTHORIZED, "인가되지 않은 사용자입니다..");
+    UNAUTHENTICATED_USER(HttpStatus.UNAUTHORIZED, "인가되지 않은 사용자입니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/devjeans/sid/global/exception/exceptionType/AuthException.java
+++ b/src/main/java/org/devjeans/sid/global/exception/exceptionType/AuthException.java
@@ -1,0 +1,22 @@
+package org.devjeans.sid.global.exception.exceptionType;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum AuthException implements ExceptionType {
+    UNAUTHENTICATED_USER(HttpStatus.UNAUTHORIZED, "인가되지 않은 사용자입니다..");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus httpStatus() {
+        return status;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/org/devjeans/sid/global/util/SecurityUtil.java
+++ b/src/main/java/org/devjeans/sid/global/util/SecurityUtil.java
@@ -1,0 +1,23 @@
+package org.devjeans.sid.global.util;
+
+import org.devjeans.sid.global.exception.BaseException;
+import org.devjeans.sid.global.exception.exceptionType.AuthException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import static org.devjeans.sid.global.exception.exceptionType.AuthException.UNAUTHENTICATED_USER;
+
+@Component
+public class SecurityUtil {
+    public Long getCurrentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        try {
+            return Long.parseLong(authentication.getName());
+        } catch(Exception e) {
+            throw new BaseException(UNAUTHENTICATED_USER);
+        }
+    }
+
+}


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- `SecurityContext`에서 현재 로그인한 회원의 `memberId`를 뽑아올 수 있는 `SecurityUtil`을 만들었습니다.

수업 시간에 SecurityContext에서 유저의 이메일을 받아와서, create 요청이 들어온 글을 쓴 author의 id나 emaildmf 요청 데이터에 받지 않고도(= 즉 글을 작성할때 유저가 수동으로 이메일을 입력하도록 하지 않고도) 어떤 유저인지 알아내서 DB에 post를 저장할 때 author 정보도 같이 넣을 수 있었고,
post를 지우거나 삭제하려고 할때, 현재 로그인한 author와 글을 작성한 author가 같은지 비교해서 글을 쓴사람만 수정, 삭제할 수 있도록 했던 것을 기억하시나요??

그 과정에서 `SecurityContext`에서 유저의 이메일을 받아왔어야했는데, 그 과정을 쉽게하기 위한 `SecurityUtil`를 만들고, `@Component` 어노테이션을 붙여서 빈으로 등록했습니다. (=즉, 다른 빈에서 DI 받아 자유롭게 사용할 수 있습니다.)
수업에서는 email을 `SecurityContext`에 usename으로 넣어놨었는데, 저희 프로젝트에서는 username이 `Long` 타입인 `memberId`입니다!!

### 그럼 이제부터 중요한거
그럼 이제부터 어떻게 해야하냐면
글의 생성 같은 요청에서 json 등으로 memberId를 받을 필요가 없습니다!
이제부터는 `SecurityUtil`에서 `getCurrentMemberId()`를 호출해서 아이디를 받아와주세요.

또한, 이제부터는 U, D api등에서 검증 로직이 들어가야합니다.
U, D api를 요청한 사용자가 적절한 권한이 있는지 판단해줘야하는 거죠 (수업 때 했던 것처럼)
굳이 U, D에 국한되지 않더라도, 유저에 대한 검증이 필요한 곳에서는 꼭 검증을 해주세요!

**기존에 인증이 아직 구현돼있지 않아서, 수동으로 memberId를 입력받게했거나, 검증이 필요한 곳에서 검증이 빠진 부분들은 수정을 부탁드립니다!**

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
아래 처럼 사용해주세요!
예전에 제가 짰던 API인데, 특정 멤버의 채팅방 목록을 모두 불러오는 api였습니다.
<img width="942" alt="image" src="https://github.com/user-attachments/assets/e1de2550-691f-4829-aaa8-13880a8cd7c6">

<img width="839" alt="image" src="https://github.com/user-attachments/assets/de903fa8-acb3-4b2f-a75c-bb49d4f74be5">

이 api는 문제가 있었는데, 현재 로그인한 유저와 요청으로 들어온 memberId가 같은지 검증하는 로직이 없어서
결국 1번 유저도 2번 유저의 채팅방 목록을 볼 수 있다는 문제가 있었습니다.

이제 검증하는 로직을 짜보겠습니다.
<img width="941" alt="스크린샷 2024-07-28 오후 4 59 39" src="https://github.com/user-attachments/assets/d55d077d-3d6b-4d56-be4b-f9d0ae2c3ed4">

이제 실행을 하고, api 호출해보겠습니다.

저는 지금 `id=1` 유저이고, 이 유저로 로그인을 해서 토큰을 발급 받았습니다.
<img width="974" alt="image" src="https://github.com/user-attachments/assets/1227c016-d352-4587-8a89-0d52e33fcc8a">

<img width="855" alt="image" src="https://github.com/user-attachments/assets/0ee6965e-5aa2-4cd0-a92a-9c299e8d0910">
그 토큰을 헤더에 넣고 1번 유저의 채팅방 목록을 보여달라고 하니까 잘 보여줍니다.
(리스트가 빈거는 그냥 데이터가 없어서 그래요!)

<img width="838" alt="image" src="https://github.com/user-attachments/assets/a2ee2108-9442-4872-8f19-96a8896d52b2">

하지만 1번 유저의 토큰을 헤더에 넣고(=즉 1번 유저로 로그인 된 상태로)
2번 유저의 채팅목록을 보여달라고 하니 에러를 던져주게되었습니다.

콘솔에 멤버 아이디도 잘 찍히는 것을 볼 수 있습니다.
이제 저 log를 찍는 코드는 삭제하겠습니다.
<img width="216" alt="image" src="https://github.com/user-attachments/assets/3cb5d7be-c93e-4348-ac67-fd6031c97c33">



## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
feat/IS-16
