### PR TITLE
Enhance/IS-18: 웹 소켓 채팅 시 jwt 토큰 검증 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
 
 	//	jwt토큰 관련 라이브러리 추가
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/devjeans/sid/config/SecurityConfigs.java
+++ b/src/main/java/org/devjeans/sid/config/SecurityConfigs.java
@@ -27,7 +27,7 @@ public class SecurityConfigs {
                 .cors().and() //CORS활성화 다른 도메인에서 서버로 호출하는 것을 금지
                 .httpBasic().disable() // 관례적으로 들어감
                 .authorizeRequests()
-                .antMatchers("/","/api/auth/register","https://kauth.kakao.com/oauth/authorize","/api/auth/kakao/callback")
+                .antMatchers("/","/api/auth/register","https://kauth.kakao.com/oauth/authorize","/api/auth/kakao/callback", "/**") // FIXME: 삭제
                 .permitAll()
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/org/devjeans/sid/config/SecurityConfigs.java
+++ b/src/main/java/org/devjeans/sid/config/SecurityConfigs.java
@@ -27,7 +27,7 @@ public class SecurityConfigs {
                 .cors().and() //CORS활성화 다른 도메인에서 서버로 호출하는 것을 금지
                 .httpBasic().disable() // 관례적으로 들어감
                 .authorizeRequests()
-                .antMatchers("/","/api/auth/register","https://kauth.kakao.com/oauth/authorize","/api/auth/kakao/callback", "/**") // FIXME: 삭제
+                .antMatchers("/","/api/auth/register","https://kauth.kakao.com/oauth/authorize","/api/auth/kakao/callback", "/chat/**") // FIXME: 삭제
                 .permitAll()
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/org/devjeans/sid/domain/auth/JwtTokenProvider.java
+++ b/src/main/java/org/devjeans/sid/domain/auth/JwtTokenProvider.java
@@ -34,16 +34,16 @@ public class JwtTokenProvider {
     }
 
     public void validateWebSocketToken(String bearerToken) {
-        log.info("validateWebSocketToken() 진입! 웹소켓 연결 시 헤더의 토큰 유효성 검증 시작!");
         try {
-            // BEARER 뒤의 실제 토큰 데이터만 남긴다.
-            log.info("line 68. 토큰 검증 {}", bearerToken);
+            // log.info("line 40. 토큰 검증 {}", bearerToken);
             String token = bearerToken.replace("Bearer ", "");
 
             Claims claims = Jwts.parser()
                     .setSigningKey(secretKey)
                     .parseClaimsJws(token)
                     .getBody();
+
+            // log.info("[line 48] 멤버 아이디: {}", claims.getSubject());
         } catch (Exception e) {
             throw new BaseException(INVALID_TOKEN);
         }

--- a/src/main/java/org/devjeans/sid/domain/auth/JwtTokenProvider.java
+++ b/src/main/java/org/devjeans/sid/domain/auth/JwtTokenProvider.java
@@ -48,4 +48,20 @@ public class JwtTokenProvider {
             throw new BaseException(INVALID_TOKEN);
         }
     }
+
+    public Long getMemberIdFromToken(String bearerToken) {
+        try {
+            // log.info("line 40. 토큰 검증 {}", bearerToken);
+            String token = bearerToken.replace("Bearer ", "");
+
+            Claims claims = Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            return Long.parseLong(claims.getSubject());
+        } catch (Exception e) {
+            throw new BaseException(INVALID_TOKEN);
+        }
+    }
 }

--- a/src/main/java/org/devjeans/sid/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/devjeans/sid/domain/auth/controller/AuthController.java
@@ -1,26 +1,17 @@
 package org.devjeans.sid.domain.auth.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.devjeans.sid.domain.auth.JwtTokenProvider;
 import org.devjeans.sid.domain.auth.service.AuthService;
-import org.devjeans.sid.domain.member.dto.MemberInfoResponse;
 import org.devjeans.sid.domain.member.dto.RegisterMemberRequest;
-import org.devjeans.sid.domain.member.dto.UpdateMemberRequest;
-import org.devjeans.sid.domain.member.dto.UpdateMemberResponse;
 import org.devjeans.sid.domain.auth.entity.KakaoRedirect;
 import org.devjeans.sid.domain.member.entity.Member;
-import org.devjeans.sid.domain.member.service.MemberService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
-
-import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/component/ConnectedMap.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/component/ConnectedMap.java
@@ -34,7 +34,7 @@ public class ConnectedMap {
     }
 
     public void enterChatRoom(Long chatRoomId, Long memberId) {
-        log.info("[connected map line 39 enter]: member id, chatrooid, sessionId: " + memberId + " " + chatRoomId);
+        log.info("[connected map line 39 enter]: member id, chatrooid: " + memberId + " " + chatRoomId);
         memberIdToChatroomId.put(memberId, chatRoomId);
     }
 

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/component/ConnectedMap.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/component/ConnectedMap.java
@@ -1,10 +1,7 @@
 package org.devjeans.sid.domain.chatRoom.component;
 
 import lombok.extern.slf4j.Slf4j;
-import org.devjeans.sid.domain.chatRoom.controller.ChatRoomValue;
 import org.springframework.stereotype.Component;
-
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -12,10 +9,14 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component
 public class ConnectedMap {
     private static final Map<Long, Long> memberIdToChatroomId = new ConcurrentHashMap<>(); // memberId, chatRoomId
-    private static final Map<String, ChatRoomValue> sessionToChatroom = new ConcurrentHashMap<>(); // 세션 아이디, ChatRoomValue
+    private static final Map<String, Long> sessionToMemberId = new ConcurrentHashMap<>(); // 세션 아이디, ChatRoomValue
 
     public Long getChatroomIdByMemberId(Long memberId) {
         return memberIdToChatroomId.get(memberId);
+    }
+
+    public Long getMemberIdBySessionId(String sessionId) {
+        return sessionToMemberId.get(sessionId);
     }
 
     // 유저가 채팅방에 입장했을 때
@@ -24,14 +25,21 @@ public class ConnectedMap {
         return chatRoomId;
     }
 
-    public void exitRoom(Long memberId) {
-        // memberIdToChatRoomId에서 지워주기
+    public void exitRoom(String sessionId) {
+        // memberIdToChatRoomId, sessionToMemberId에서 지워주기
+        Long memberId = sessionToMemberId.get(sessionId);
         log.info("[connected map line 28 exit]: member id: " + memberId);
         memberIdToChatroomId.remove(memberId);
+        sessionToMemberId.remove(sessionId);
     }
 
     public void enterChatRoom(Long chatRoomId, Long memberId) {
-        log.info("[connected map line 39 enter]: member id, chatrooid: " + memberId + " " + chatRoomId);
+        log.info("[connected map line 39 enter]: member id, chatrooid, sessionId: " + memberId + " " + chatRoomId);
         memberIdToChatroomId.put(memberId, chatRoomId);
+    }
+
+    public void addSession(String sessionId, Long memberId) {
+        log.info("line 43: add session {}", sessionId + " memberId: " + memberId);
+        sessionToMemberId.put(sessionId, memberId);
     }
 }

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/component/StompHandler.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/component/StompHandler.java
@@ -37,9 +37,7 @@ public class StompHandler implements ChannelInterceptor {
         // 클라이언트에서 첫 연결 시 헤더에 TOKEN을 담아주면 인증 절차가 진행된다.
         final StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
 
-        log.info("preSend 진입했나?");
-        log.info("[line 34] " + accessor);
-        log.info("[line 34] " + message.getPayload());
+        log.info("preSend 진입");
         // 웹소켓 연결 시 헤더의 jwt token 유효성 검증
         String bearerToken = null;
         if (StompCommand.CONNECT == accessor.getCommand()) {
@@ -49,12 +47,11 @@ public class StompHandler implements ChannelInterceptor {
             // type: 사용하는 인증 방식.(e.g., Bearer)
             // credentials: 인증 방식에 따른 인증 정보(토큰)를 의미한다. 발급받은 JWT 토큰
             bearerToken = accessor.getFirstNativeHeader("Authorization");
-            log.info("line 52. authorization = {}", bearerToken);
             // 토큰 검증
             jwtTokenProvider.validateWebSocketToken(bearerToken);
 
             // 토큰 검증 통과
-            log.info("토큰 검증 통과! WebSocket CONNECT!");
+            log.info("토큰 검증 통과 WebSocket CONNECT");
 
 
             // 저장
@@ -64,9 +61,9 @@ public class StompHandler implements ChannelInterceptor {
         }
 
         if (StompCommand.DISCONNECT == accessor.getCommand()) {
-            log.info("WebSocket DISCONNECT!");
+            log.info("WebSocket DISCONNECT");
             String sessionId = accessor.getSessionId();
-            log.info("[line 63] Disconnect. token: {}", bearerToken); // null
+//            log.info("[line 63] Disconnect. token: {}", bearerToken); // null
             connectedMap.exitRoom(sessionId);
         }
 

--- a/src/main/java/org/devjeans/sid/domain/chatRoom/component/StompHandler.java
+++ b/src/main/java/org/devjeans/sid/domain/chatRoom/component/StompHandler.java
@@ -44,10 +44,9 @@ public class StompHandler implements ChannelInterceptor {
         if (StompCommand.CONNECT == accessor.getCommand()) {
             log.info("웹소켓 토큰 검증 시작!");
             // "Authorization"이라는 이름의 헤더를 찾아 그 헤더의 첫 번째 값을 반환.
-            // "Authorization" 헤더는 클라이언트가 서버로 보낸 요청에 대한 인증 정보(JWT 토큰)를 포함한다.
             // Authorization 헤더의 형식 => `Authorization: <type> <credentials>`
             // type: 사용하는 인증 방식.(e.g., Bearer)
-            // credentials: 인증 방식에 따른 인증 정보(토큰)를 의미한다. 발급받은 JWT 토큰!
+            // credentials: 인증 방식에 따른 인증 정보(토큰)를 의미한다. 발급받은 JWT 토큰
             final String authorization = accessor.getFirstNativeHeader("Authorization");
             log.info("line 52. authorization = {}", authorization);
             // 토큰 검증

--- a/src/main/resources/static/chat.html
+++ b/src/main/resources/static/chat.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>STOMP WebSocket Chat</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.1.2/sockjs.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+    <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+    <style>
+        .chat-container {
+            display: flex;
+            justify-content: space-between;
+        }
+        .chat-box {
+            width: 45%;
+            border: 1px solid #ccc;
+            padding: 10px;
+        }
+        .messages {
+            height: 300px;
+            overflow-y: auto;
+            border: 1px solid #ccc;
+            margin-bottom: 10px;
+            padding: 5px;
+        }
+    </style>
+    <script>
+        var stompClient1 = null;
+        var stompClient2 = null;
+        var chatRoomId = 1;
+
+        function connect(userId) {
+            var socket = new SockJS('http://localhost:8080/chat');
+            var stompClient = Stomp.over(socket);
+            // enter chatroom api 시작
+            const response = axios.post("http://localhost:8080/api/chat/chatroom/1/entrance/member/"+userId);
+
+            // 헤더에 토큰 끼워넣는 부분
+            const authToken = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3MjIxNTMyNzcsImV4cCI6MTcyNDc0NTI3N30.mmOd-DSfAduSTWuTh5HdewBDP6dez2afR7RvvfDF8jE';
+            stompClient.connect({Authorization: `Bearer ${authToken}`}, function (frame) {
+                console.log('Connected: ' + frame);
+
+                // 수신할 메시지를 구독합니다.
+                stompClient.subscribe('/sub/chatroom/' + chatRoomId, async function (message) {
+                    console.log("line 38 구독 시작!" + userId);
+                    showMessage(userId, JSON.parse(message.body));
+                });
+            });
+
+
+            socket.onclose = function() {
+                console.log('WebSocket connection closed for user ' + userId);
+            }
+
+
+
+            return stompClient;
+        }
+
+        function disconnect(stompClient) {
+            if (stompClient !== null) {
+                stompClient.disconnect();
+            }
+            console.log("Disconnected");
+        }
+
+        async function sendMessage(stompClient, userId, receiverId) {
+            var messageInput = document.getElementById("messageInput" + userId).value;
+            // var content = document.getElementById("message" + userId).value;
+            if (messageInput && stompClient) {
+                var chatMessage = {
+                    senderId: userId,
+                    chatRoomId: 1,
+                    content: messageInput
+                };
+                stompClient.send("/pub/" + chatRoomId + "/receiver/" + receiverId, {}, JSON.stringify(chatMessage));
+                document.getElementById("messageInput" + userId).value = '';
+            }
+        }
+
+        async function showMessage(userId, message) {
+            var messagesDiv = document.getElementById("messages" + userId);
+            var messageElement = document.createElement('div');
+            messageElement.innerText = message.senderId + ": " + message.content + " (" + new Date(message.timestamp).toLocaleTimeString() + ")";
+            messagesDiv.appendChild(messageElement);
+        }
+
+        window.onload = function() {
+            stompClient1 = connect(1);
+            stompClient2 = connect(2);
+        };
+    </script>
+</head>
+<body>
+<div class="chat-container">
+    <div class="chat-box">
+        <h3>User 1</h3>
+        <div id="messages1" class="messages"></div>
+        <input type="text" id="messageInput1" placeholder="Type your message here...">
+        <button onclick="sendMessage(stompClient1, 1, 2)">Send</button>
+    </div>
+    <div class="chat-box">
+        <h3>User 2</h3>
+        <div id="messages2" class="messages"></div>
+        <input type="text" id="messageInput2" placeholder="Type your message here...">
+        <button onclick="sendMessage(stompClient2, 2, 1)">Send</button>
+    </div>
+</div>
+<button onclick="disconnect(stompClient1)">Disconnect User 1</button>
+<button onclick="disconnect(stompClient2)">Disconnect User 2</button>
+</body>
+</html>

--- a/src/main/resources/static/chat.html
+++ b/src/main/resources/static/chat.html
@@ -32,10 +32,14 @@
             var socket = new SockJS('http://localhost:8080/chat');
             var stompClient = Stomp.over(socket);
             // enter chatroom api 시작
-            const response = axios.post("http://localhost:8080/api/chat/chatroom/1/entrance/member/"+userId);
+            const authToken = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3MjIxNTMyNzcsImV4cCI6MTcyNDc0NTI3N30.mmOd-DSfAduSTWuTh5HdewBDP6dez2afR7RvvfDF8jE';
+            const response = axios.post("http://localhost:8080/api/chat/chatroom/" + userId+ "/entrance/member/"+userId, {}, {
+                headers: {
+                    Authorization: `Bearer ${authToken}`
+                }
+            });
 
             // 헤더에 토큰 끼워넣는 부분
-            const authToken = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3MjIxNTMyNzcsImV4cCI6MTcyNDc0NTI3N30.mmOd-DSfAduSTWuTh5HdewBDP6dez2afR7RvvfDF8jE';
             stompClient.connect({Authorization: `Bearer ${authToken}`}, function (frame) {
                 console.log('Connected: ' + frame);
 


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- 웹 소켓시 JWT 토근 인증 로직 추가
- 채팅 읽음 처리를 위해 `ConnectedMap`에 `세션 아이디 - 멤버아이디`, `멤버아이디 - 채팅방 아이디`를 저장하는 2개의 맵 생성


## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
결과화면은 없지만,, 이 부분의 로직이 추가, 변경되었습니다.
<img width="906" alt="image" src="https://github.com/user-attachments/assets/0396c9fb-8197-4491-a32a-f97d849e107c">

이제 웹 소켓에 연결해서 채팅할 때, 헤더에 jwt 토큰을 넣어야 채팅 가능합니다.

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
`enhance/IS-18`-> `main`