### PR TITLE
feat/IS-20: kakao email 추가 및 코드 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,8 +54,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	//	jwt토큰 관련 라이브러리 추가
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
-
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/devjeans/sid/domain/auth/JwtTokenProvider.java
+++ b/src/main/java/org/devjeans/sid/domain/auth/JwtTokenProvider.java
@@ -18,6 +18,7 @@ public class JwtTokenProvider {
     private String secretKey;
     @Value("${jwt.expiration}")
     private int expiration;
+    private static final Long expriationPeriod = 24*60*60*1000L;
 
     public String createToken(String id, String role) {
 //        Claims는 사용자 정보(페이로드 정보)
@@ -27,7 +28,7 @@ public class JwtTokenProvider {
         String token = Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now) // 생성시간                일수 시간 분 초 밀리초
-                .setExpiration(new Date(now.getTime()+expiration*24*60*60*1000L)) // 만료시간 30분
+                .setExpiration(new Date(now.getTime()+expiration*expriationPeriod)) // 만료시간 30분
                 .signWith(SignatureAlgorithm.HS256,secretKey)
                 .compact();
         return token;

--- a/src/main/java/org/devjeans/sid/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/devjeans/sid/domain/auth/controller/AuthController.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.devjeans.sid.domain.auth.JwtTokenProvider;
+import org.devjeans.sid.domain.auth.dto.KakaoProfileResDto;
+import org.devjeans.sid.domain.auth.dto.CommonResDto;
+import org.devjeans.sid.domain.auth.entity.KakaoProfile;
 import org.devjeans.sid.domain.auth.service.AuthService;
 import org.devjeans.sid.domain.member.dto.RegisterMemberRequest;
 import org.devjeans.sid.domain.auth.entity.KakaoRedirect;
@@ -30,16 +33,17 @@ public class AuthController {
 
     @GetMapping("/kakao/callback")
     public ResponseEntity<?> kakaoCallback(KakaoRedirect kakaoRedirect) throws JsonProcessingException {
-        Long kakaoId = authService.login(kakaoRedirect);
-        System.out.println(kakaoId);
+        KakaoProfile kakaoProfile = authService.login(kakaoRedirect);
+        System.out.println(kakaoProfile.getId());
 
 //            가입자 or 비가입자 체크해서 처리
-        Member originMember = authService.getMemberByKakaoId(kakaoId);
+        Member originMember = authService.getMemberByKakaoId(kakaoProfile.getId());
         System.out.println(originMember);
         if(originMember == null) {
 //           신규 회원일경우 errorResponse에 소셜id를 담아 예외를 프론트로 던지기
 //            프론트는 예외일경우 회원가입 화면으로 이동하여 회원가입 정보와 소셜id를 담아 다시 회원가입 요청
-            return new ResponseEntity<>(kakaoId,HttpStatus.UNAUTHORIZED);
+            CommonResDto commonResDto = new CommonResDto(HttpStatus.UNAUTHORIZED,"기존 회원이 아닙니다. 회원가입을 진행해주세요.",new KakaoProfileResDto(kakaoProfile.getId(),kakaoProfile.getKakao_account().email));
+            return new ResponseEntity<>(commonResDto,HttpStatus.UNAUTHORIZED);
         }
         String jwtToken = jwtTokenProvider.createToken(String.valueOf(originMember.getId()),originMember.getRole().toString());
         Map<String,Object> loginInfo = new HashMap<>();
@@ -49,13 +53,13 @@ public class AuthController {
         return new ResponseEntity<>(loginInfo,HttpStatus.OK);
     }
 
-    @GetMapping("register")
+    @PostMapping("register")
     public ResponseEntity<String> registerMember(@RequestBody RegisterMemberRequest dto) {
         authService.registerMember(dto);
         return new ResponseEntity<>("register succes!!", HttpStatus.OK);
     }
 
-    @GetMapping("delete")
+    @DeleteMapping("delete")
     public ResponseEntity<String> deleteMember() {
 //        String tmp = SecurityContextHolder.getContext().getAuthentication().getName();
         Member member = authService.delete();

--- a/src/main/java/org/devjeans/sid/domain/auth/dto/CommonResDto.java
+++ b/src/main/java/org/devjeans/sid/domain/auth/dto/CommonResDto.java
@@ -1,0 +1,21 @@
+package org.devjeans.sid.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommonResDto {
+    private int status_code;
+    private String status_message;
+    private Object result;
+
+    public CommonResDto(HttpStatus httpStatus, String message, Object result){
+        this.status_code = httpStatus.value();
+        this.status_message = message;
+        this.result = result;
+    }
+}

--- a/src/main/java/org/devjeans/sid/domain/auth/dto/KakaoProfileResDto.java
+++ b/src/main/java/org/devjeans/sid/domain/auth/dto/KakaoProfileResDto.java
@@ -1,0 +1,13 @@
+package org.devjeans.sid.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoProfileResDto {
+    private Long social_id;
+    private String social_email;
+}

--- a/src/main/java/org/devjeans/sid/domain/auth/entity/KakaoProfile.java
+++ b/src/main/java/org/devjeans/sid/domain/auth/entity/KakaoProfile.java
@@ -3,8 +3,17 @@ import lombok.Data;
 
 @Data
 public class KakaoProfile {
-    public Long id;
-    public String connected_at;
+    private Long id;
+    private String connected_at;
+    private KakaoAccount kakao_account;
+
+    public class KakaoAccount{
+        public Boolean has_email;
+        public Boolean email_needs_agreement;
+        public Boolean is_email_valid;
+        public Boolean is_email_verified;
+        public String email;
+    }
 }
 
 

--- a/src/main/java/org/devjeans/sid/domain/auth/service/AuthService.java
+++ b/src/main/java/org/devjeans/sid/domain/auth/service/AuthService.java
@@ -33,6 +33,7 @@ import static java.rmi.server.LogStream.log;
 @Slf4j
 @RequiredArgsConstructor
 @Service
+//@PropertySource("classpath:application.yml")
 @Transactional
 public class AuthService {
     private final MemberRepository memberRepository;
@@ -40,10 +41,10 @@ public class AuthService {
     @Value("${auth.oauth.kakao.api}")
     private String authOauthKakaoApi;
 
-    public Long login(KakaoRedirect kakaoRedirect) throws JsonProcessingException {
+    public KakaoProfile login(KakaoRedirect kakaoRedirect) throws JsonProcessingException {
         OAuthToken oAuthToken = getAccessToken(kakaoRedirect);
-        Long kakaoId = getKakaoId(oAuthToken.getAccess_token());
-        return kakaoId;
+        KakaoProfile kakaoProfile = getKakaoProfile(oAuthToken.getAccess_token());
+        return kakaoProfile;
     }
 
     public OAuthToken getAccessToken(KakaoRedirect kakaoRedirect) throws JsonProcessingException {
@@ -72,7 +73,7 @@ public class AuthService {
         return oAuthToken;
     }
 
-    public Long getKakaoId(String accessToken) throws JsonProcessingException {
+    public KakaoProfile getKakaoProfile(String accessToken) throws JsonProcessingException {
         RestTemplate rt = new RestTemplate();
 
 //        HttpHeader 오브젝트 생성
@@ -95,7 +96,7 @@ public class AuthService {
         ObjectMapper objectMapper2 = new ObjectMapper();
         KakaoProfile kakaoProfile = objectMapper2.readValue(response2.getBody(), KakaoProfile.class);
 
-        return kakaoProfile.getId();
+        return kakaoProfile;
     }
 
     public void registerMember(RegisterMemberRequest dto) {

--- a/src/main/java/org/devjeans/sid/domain/member/service/MemberService.java
+++ b/src/main/java/org/devjeans/sid/domain/member/service/MemberService.java
@@ -28,8 +28,6 @@ public class MemberService {
     private final RedisTemplate<String, MemberIdEmailCode> redisTemplate;
     private final SecurityUtil securityUtil;
 
-    @Value("${auth.oauth.kakao.api}")
-    private String authOauthKakaoApi;
     public MemberInfoResponse getMemberInfo(Long memberId) {
         // TODO: 인증, 인가 구현 후 멤버 아이디와 시큐리티 컨텍스트의 멤버가 동일한지 확인하는 로직 필요
 


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [ ] 기능 수정
- [x] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
이제 카카오 이메일을 받아올 수 있어서 로그인할때 응답으로 받은 이메일도 같이 회원가입 바디에 담아서 보내주시면 됩니

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
![image](https://github.com/user-attachments/assets/45714d0d-fe9a-48ed-8438-6d6cff0fbb2b)
로그인 요청 uri : https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=f1a9f25e347069f2e5fedb6375c0b82d&redirect_uri=http://localhost:8080/api/auth/kakao/callback
위 링크로 요청하시면 id email 얻을 수 있는데 회원가입할때 받은 정보 그대로 담아 회원가입 하시면 됩니다.
![image](https://github.com/user-attachments/assets/60eaa1d3-5f84-45c9-b7c3-8db8bfd53b75)


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
feat/IS-20