### PR TITLE
feat/IS-65 fix : 메인페이지 TopMemberList api 수정

### DIFF
--- a/src/main/java/org/devjeans/sid/domain/mainPage/dto/TopListMemberResponse.java
+++ b/src/main/java/org/devjeans/sid/domain/mainPage/dto/TopListMemberResponse.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.devjeans.sid.domain.member.entity.Member;
+import org.devjeans.sid.domain.project.entity.JobField;
 
 @Getter
 @Builder
@@ -15,5 +17,8 @@ public class TopListMemberResponse {
     private String nickname; // 닉네임
 
     private String profileImageUrl; // 프로필 이미지 Url
+
+    private JobField jobField; // 직무
+
 
 }

--- a/src/main/java/org/devjeans/sid/domain/mainPage/service/MainPageService.java
+++ b/src/main/java/org/devjeans/sid/domain/mainPage/service/MainPageService.java
@@ -10,9 +10,11 @@ import org.devjeans.sid.domain.mainPage.dto.TopListMemberResponse;
 import org.devjeans.sid.domain.member.entity.Member;
 import org.devjeans.sid.domain.member.repository.MemberRepository;
 import org.devjeans.sid.domain.project.dto.read.ListProjectResponse;
+import org.devjeans.sid.domain.project.entity.JobField;
 import org.devjeans.sid.domain.project.entity.Project;
 import org.devjeans.sid.domain.project.repository.ProjectRepository;
 import org.devjeans.sid.domain.project.service.ProjectService;
+import org.devjeans.sid.domain.siderCard.repository.SiderCardRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -34,18 +36,21 @@ public class MainPageService {
     private final LaunchedProjectViewService launchedProjectViewService;
     private final LaunchedProjectScrapService launchedProjectScrapService;
     private final ProjectService projectService;
+    private final SiderCardRepository siderCardRepository;
 
     @Autowired
     public MainPageService(LaunchedProjectRepository launchedProjectRepository,
                            MemberRepository memberRepository,
                            LaunchedProjectViewService launchedProjectViewService,
                            LaunchedProjectScrapService launchedProjectScrapService,
-                           ProjectService projectService){
+                           ProjectService projectService,
+                           SiderCardRepository siderCardRepository){
         this.launchedProjectRepository = launchedProjectRepository;
         this.memberRepository = memberRepository;
         this.launchedProjectViewService = launchedProjectViewService;
         this.launchedProjectScrapService = launchedProjectScrapService;
         this.projectService = projectService;
+        this.siderCardRepository = siderCardRepository;
     }
 
     // 조회수 순으로 8개 Page (+아직 마감/삭제되지 않은 모집공고)
@@ -83,7 +88,10 @@ public class MainPageService {
     // 최신회원 6명
     public Page<TopListMemberResponse> getTopMembers(Pageable pageable){
         Page<Member> members = memberRepository.findAllByOrderByUpdatedAtDesc(pageable);
-        Page<TopListMemberResponse> topListMemberResponsePage = members.map(member -> member.topListResFromMember(member));
+        Page<TopListMemberResponse> topListMemberResponsePage = members.map(member -> {
+            JobField jobField = siderCardRepository.findByIdOrThrow(member.getId()).getJobField();
+            return member.topListResFromMember(member, jobField);
+        });
         return topListMemberResponsePage;
     }
 

--- a/src/main/java/org/devjeans/sid/domain/member/entity/Member.java
+++ b/src/main/java/org/devjeans/sid/domain/member/entity/Member.java
@@ -8,6 +8,7 @@ import org.devjeans.sid.domain.common.BaseEntity;
 import org.devjeans.sid.domain.mainPage.dto.TopListMemberResponse;
 import org.devjeans.sid.domain.member.dto.UpdateMemberRequest;
 
+import org.devjeans.sid.domain.project.entity.JobField;
 import org.devjeans.sid.domain.project.entity.ProjectMember;
 
 
@@ -90,13 +91,15 @@ public class Member extends BaseEntity {
         this.email = email;
     }
 
-    public static TopListMemberResponse topListResFromMember(Member member){
+    public static TopListMemberResponse topListResFromMember(Member member,
+                                                             JobField jobField){
+
         return TopListMemberResponse.builder()
                 .id(member.getId())
                 .nickname(member.getNickname())
                 .profileImageUrl(member.getProfileImageUrl())
+                .jobField(jobField)
                 .build();
     }
-
 
 }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
## 메인페이지 TopMemberList api 수정
member의 jobfield 까지 response하도록 수정

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
![image](https://github.com/user-attachments/assets/8c6f00f1-31e7-4e48-97f0-cf9823a6f845)

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
feat/IS-65