### PR TITLE
fix/IS-128 : 로그인 없어도 project list 및 detail 조회 가능하게 수정

### DIFF
--- a/src/main/java/org/devjeans/sid/config/SecurityConfigs.java
+++ b/src/main/java/org/devjeans/sid/config/SecurityConfigs.java
@@ -38,6 +38,8 @@ public class SecurityConfigs {
                         "/api/main/top-sider-card",
                         "/api/main/top-project",
                         "/api/project/listAll",
+                        "/api/project/{id}",
+                        "/api/project/{id}/isScrap",
                         "/api/sider-card/list")
                 .permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/org/devjeans/sid/domain/project/controller/ProjectController.java
+++ b/src/main/java/org/devjeans/sid/domain/project/controller/ProjectController.java
@@ -10,6 +10,7 @@ import org.devjeans.sid.domain.project.dto.update.UpdateProjectResponse;
 import org.devjeans.sid.domain.project.entity.Project;
 import org.devjeans.sid.domain.project.service.ProjectService;
 import org.devjeans.sid.domain.project.service.ScrapService;
+import org.devjeans.sid.global.util.SecurityUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,6 +19,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -26,10 +29,13 @@ import java.util.stream.Collectors;
 public class ProjectController {
     private final ProjectService projectService;
     private final ScrapService scrapService;
+    private final SecurityUtil securityUtil;
+
     @Autowired
-    public ProjectController(ProjectService projectService, ScrapService scrapService) {
+    public ProjectController(ProjectService projectService, ScrapService scrapService, SecurityUtil securityUtil) {
         this.projectService = projectService;
         this.scrapService = scrapService;
+        this.securityUtil = securityUtil;
     }
 
     // project create
@@ -108,8 +114,17 @@ public class ProjectController {
     public ResponseEntity<List<ListProjectResponse>> listAll(
             @RequestParam(defaultValue = "recent") String sorted
     ){
+
         List<ListProjectResponse> listProjectResponses = projectService.projectListReadAll(sorted);
+//        if(securityUtil.isMember()) listProjectResponses = projectService.projectListReadAll(sorted);
+//        else listProjectResponses = projectService.projectListReadAllNotMember(sorted);
         return new ResponseEntity<>(listProjectResponses,HttpStatus.OK);
+    }
+
+    @GetMapping("/api/project/{id}/isScrap")
+    public ResponseEntity<Boolean> isScrap(@PathVariable Long id){
+        boolean isScrap = scrapService.isProjectScrappedByMember(id);
+        return new ResponseEntity<>(isScrap,HttpStatus.OK);
     }
 
 

--- a/src/main/java/org/devjeans/sid/domain/project/dto/read/DetailProjectResponse.java
+++ b/src/main/java/org/devjeans/sid/domain/project/dto/read/DetailProjectResponse.java
@@ -32,7 +32,7 @@ public class DetailProjectResponse {
     private Long id;
     private String imageUrl;
     private String projectName;
-    private boolean isScrap;
+//    private boolean isScrap;
     private String description;
     private LocalDateTime createdAt;
 
@@ -88,7 +88,7 @@ public class DetailProjectResponse {
 
 //    private List<ChatRoomDto> chatRooms;
 
-    public static DetailProjectResponse fromEntity(Project project, Long scrapCount, Long views, boolean isScrap, ApplicantsCountResDto dto){
+    public static DetailProjectResponse fromEntity(Project project, Long scrapCount, Long views, ApplicantsCountResDto dto){
         List<RecruitInfo> recruitInfoList = project.getRecruitInfos();
         List<ProjectScrap> projectScrapList = project.getProjectScraps();
         List<ChatRoom> chatRoomList=project.getChatRooms();
@@ -122,7 +122,7 @@ public class DetailProjectResponse {
 
         return DetailProjectResponse.builder()
                 .id(project.getId())
-                .isScrap(isScrap)
+//                .isScrap(isScrap)
                 .imageUrl(project.getImageUrl())
                 .pmId(project.getPm().getId())
                 .pmName(project.getPm().getName())

--- a/src/main/java/org/devjeans/sid/domain/project/repository/ProjectScrapRepository.java
+++ b/src/main/java/org/devjeans/sid/domain/project/repository/ProjectScrapRepository.java
@@ -7,7 +7,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 //import org.devjeans.sid.domain.projectScrap.entity.ProjectScrap;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.repository.query.Param;
 
 @Repository
 public interface ProjectScrapRepository extends JpaRepository<ProjectScrap,Long> {
@@ -15,5 +17,7 @@ public interface ProjectScrapRepository extends JpaRepository<ProjectScrap,Long>
     Page<ProjectScrap> findByMemberId(Long memberId,Pageable pageable);
     ProjectScrap findByProjectIdAndMemberId(Long projectId, Long memberId);
     Boolean existsByProjectAndMember(Project project, Member member);
+    @Query("SELECT COUNT(ps) FROM ProjectScrap ps WHERE ps.project.id = :projectId")
+    long countByProjectId(@Param("projectId") Long projectId);
 
 }

--- a/src/main/java/org/devjeans/sid/domain/project/service/ProjectScheduler.java
+++ b/src/main/java/org/devjeans/sid/domain/project/service/ProjectScheduler.java
@@ -104,6 +104,7 @@ public class ProjectScheduler {
 
     @Qualifier("scrapRedisTemplate")
     @Scheduled(cron = "0 0 4 * * *")
+//    @Scheduled(cron = "* * * * * *")
     @Transactional
     public void syncScraps() {
         //set(MEMBER_SCRAP_LIST+memberId).members = project id들
@@ -129,17 +130,21 @@ public class ProjectScheduler {
             }
         }
 
-        // project count도 복구
         for(Project p : projectRepository.findAll()){
-            // scrap 저장
+            // scrapCount
+            Long scrapCount = 0L;
+
             String projectKey = PROJECT_SCRAP_COUNT + p.getId();
             ValueOperations<String, Object> valueOperations = scrapRedisTemplate.opsForValue();
             Object count = valueOperations.get(projectKey);
             if(count !=null){
-                Long views = Long.valueOf(count.toString());
-                p.setScrapCount(views);
-                projectRepository.save(p);
+                scrapCount = Long.valueOf(count.toString());
+
             }
+            p.setScrapCount(scrapCount);
+            projectRepository.save(p);
         }
+
+
     }
 }

--- a/src/main/java/org/devjeans/sid/domain/project/service/ScrapService.java
+++ b/src/main/java/org/devjeans/sid/domain/project/service/ScrapService.java
@@ -155,8 +155,19 @@ public class ScrapService {
     }
 
     public boolean isProjectScrappedByMember(Long projectId) {
-        String memberKey = MEMBER_SCRAP_LIST + securityUtil.getCurrentMemberId();
-        SetOperations<String, Object> setOperations = scrapRedisTemplate.opsForSet();
-        return Boolean.TRUE.equals(setOperations.isMember(memberKey, projectId));
+//        String memberKey = MEMBER_SCRAP_LIST + securityUtil.getCurrentMemberId();
+//        SetOperations<String, Object> setOperations = scrapRedisTemplate.opsForSet();
+//        return Boolean.TRUE.equals(setOperations.isMember(memberKey, projectId));
+        boolean isScrap=false;
+        if(securityUtil.isMember().equals(true)) {
+            String memberKey = MEMBER_SCRAP_LIST + securityUtil.getCurrentMemberId();
+            SetOperations<String, Object> setOperations = scrapRedisTemplate.opsForSet();
+            isScrap = setOperations.isMember(memberKey, projectId);
+        }
+        return isScrap;
+
     }
+
+
+
 }

--- a/src/main/java/org/devjeans/sid/global/util/SecurityUtil.java
+++ b/src/main/java/org/devjeans/sid/global/util/SecurityUtil.java
@@ -19,5 +19,10 @@ public class SecurityUtil {
             throw new BaseException(UNAUTHENTICATED_USER);
         }
     }
+    public Boolean isMember(){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(authentication.getPrincipal().equals("anonymousUser")) return false;
+        else return true;
+    }
 
 }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
project list 및 detail 로그인 없이 조회 가능하게 수정

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
- project list api(auth 없이 실행 & url : http://localhost:8080/api/project/list )
![no auth list postman](https://github.com/user-attachments/assets/7e66df43-fe83-410a-84da-ef7848026f22)

- project detail api (auth 없이 실행 & url : http://localhost:8080/api/project/1)
![no auth 포스트맨](https://github.com/user-attachments/assets/4f846506-a9c1-4f2b-a3dc-9fc1cf0f50ab)

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->
security utils에서 isMember 함수를 추가했는데 이와 관련해서 언제든지 의견 말씀해주시면 수정하겠습니다!

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
fix/IS-128